### PR TITLE
feat(frontend): 持ち物にあるアイテムを部屋に配置

### DIFF
--- a/frontend/src/features/room/hooks/useItemAcquisition.ts
+++ b/frontend/src/features/room/hooks/useItemAcquisition.ts
@@ -258,6 +258,18 @@ export function useItemAcquisition({
     resetFlow,
   ]);
 
+  /**
+   * 持ち物から配置モードに入る
+   */
+  const startPlacementFromInventory = useCallback(
+    (calendarItem: CalendarItemWithItem) => {
+      setTargetCalendarItem(calendarItem);
+      setTargetDay(null); // 持ち物からの配置なので日付は不要
+      setPhase("placement");
+    },
+    [],
+  );
+
   return {
     phase,
     targetCalendarItem,
@@ -270,6 +282,7 @@ export function useItemAcquisition({
     handlePlacement,
     handleSkipPlacement,
     resetFlow,
+    startPlacementFromInventory,
     isPending,
   };
 }

--- a/frontend/src/features/room/inventoryDialog.tsx
+++ b/frontend/src/features/room/inventoryDialog.tsx
@@ -73,10 +73,12 @@ export default function InventoryDialog({
   roomId,
   open,
   onOpenChange,
+  onStartPlacement,
 }: {
   roomId: string;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  onStartPlacement?: (calendarItem: CalendarItemWithItem) => void;
 }) {
   const { data: calendarItems = [], isLoading } =
     useGetCalendarItemsRoomIdCalendarItemsInventory(roomId);
@@ -92,10 +94,14 @@ export default function InventoryDialog({
   }, [calendarItems]);
 
   const handlePlaceItem = () => {
-    if (selectedItemId) {
-      // TODO: 部屋にアイテムを配置する処理を実装
-      console.log("Placing item:", selectedItemId);
-      onOpenChange(false);
+    if (selectedItemId && onStartPlacement) {
+      const selectedItem = calendarItems.find(
+        (item) => item.item.id === selectedItemId,
+      );
+      if (selectedItem) {
+        onStartPlacement(selectedItem);
+        onOpenChange(false);
+      }
     }
   };
 

--- a/frontend/src/features/room/placedItems.tsx
+++ b/frontend/src/features/room/placedItems.tsx
@@ -1,10 +1,10 @@
 import { Gltf } from "@react-three/drei";
 import { RigidBody } from "@react-three/rapier";
-import type { CalendarItemWithItem } from "common/generate/adventSphereAPI.schemas";
+import type { CalendarItem } from "common/generate/adventSphereAPI.schemas";
 import { R2_BASE_URL } from "@/constants/r2-url";
 
 interface PlacedItemsProps {
-  calendarItems: CalendarItemWithItem[] | undefined;
+  calendarItems: CalendarItem[] | undefined;
 }
 
 /**
@@ -13,14 +13,9 @@ interface PlacedItemsProps {
 export default function PlacedItems({ calendarItems }: PlacedItemsProps) {
   if (!calendarItems) return null;
 
-  // position が設定されているアイテムのみ表示
-  const placedItems = calendarItems.filter(
-    (item) => item.position && item.position.length === 3,
-  );
-
   return (
     <>
-      {placedItems.map((item) => (
+      {calendarItems.map((item) => (
         <PlacedItem key={item.id} calendarItem={item} />
       ))}
     </>
@@ -28,7 +23,7 @@ export default function PlacedItems({ calendarItems }: PlacedItemsProps) {
 }
 
 interface PlacedItemProps {
-  calendarItem: CalendarItemWithItem;
+  calendarItem: CalendarItem;
 }
 
 function PlacedItem({ calendarItem }: PlacedItemProps) {

--- a/frontend/src/routes/$roomId/index.lazy.tsx
+++ b/frontend/src/routes/$roomId/index.lazy.tsx
@@ -72,6 +72,7 @@ function RouteComponent() {
     handlePlacement,
     handleSkipPlacement,
     resetFlow,
+    startPlacementFromInventory,
     isPending,
   } = useItemAcquisition({
     roomId,
@@ -199,6 +200,7 @@ function RouteComponent() {
           roomId={roomId}
           open={isInventoryDialogOpen}
           onOpenChange={setIsInventoryDialogOpen}
+          onStartPlacement={startPlacementFromInventory}
         />
         {isFocusMode && !isPlacementMode && (
           <Button

--- a/frontend/src/routes/$roomId/index.lazy.tsx
+++ b/frontend/src/routes/$roomId/index.lazy.tsx
@@ -2,7 +2,10 @@ import { CameraControls, Environment, Gltf } from "@react-three/drei";
 import { Canvas } from "@react-three/fiber";
 import { Physics, RigidBody } from "@react-three/rapier";
 import { createLazyFileRoute } from "@tanstack/react-router";
-import { useGetCalendarItemsRoomIdCalendarItems } from "common/generate/calendar-items/calendar-items";
+import {
+  useGetCalendarItemsRoomIdCalendarItems,
+  useGetCalendarItemsRoomIdCalendarItemsRoom,
+} from "common/generate/calendar-items/calendar-items";
 import { useGetRoomsId } from "common/generate/room/room";
 import { X } from "lucide-react";
 import { Suspense, useMemo, useRef, useState } from "react";
@@ -49,6 +52,8 @@ function RouteComponent() {
   const { data: room } = useGetRoomsId(roomId);
   const { data: calendarItems } =
     useGetCalendarItemsRoomIdCalendarItems(roomId);
+  const { data: calendarItemsRoom } =
+    useGetCalendarItemsRoomIdCalendarItemsRoom(roomId);
   const [isInventoryDialogOpen, setIsInventoryDialogOpen] = useState(false);
   const [openedDrawers, setOpenedDrawers] = useState<number[]>([]);
   const {
@@ -289,7 +294,7 @@ function RouteComponent() {
               </group>
 
               {/* 配置済みアイテム */}
-              <PlacedItems calendarItems={calendarItems} />
+              <PlacedItems calendarItems={calendarItemsRoom} />
 
               {/* 配置モード時のドラッグ可能アイテム */}
               {isPlacementMode && targetCalendarItem && roomRef && (


### PR DESCRIPTION
close: #55 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * インベントリからのアイテム配置機能を追加しました。ダイアログからアイテムを選択すると、配置モードが起動し、室内に直接配置できるようになります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->