### PR TITLE
feat: cascadeを使って関連データを自動削除

### DIFF
--- a/backend/drizzle/0006_glossy_lockjaw.sql
+++ b/backend/drizzle/0006_glossy_lockjaw.sql
@@ -1,0 +1,38 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_calendar_item` (
+	`id` text PRIMARY KEY NOT NULL,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	`room_id` text NOT NULL,
+	`user_id` text NOT NULL,
+	`open_date` integer NOT NULL,
+	`position` text,
+	`rotation` text,
+	`is_opened` integer DEFAULT false NOT NULL,
+	`item_id` text NOT NULL,
+	`image_id` text,
+	FOREIGN KEY (`room_id`) REFERENCES `room`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`item_id`) REFERENCES `item`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+INSERT INTO `__new_calendar_item`("id", "created_at", "room_id", "user_id", "open_date", "position", "rotation", "is_opened", "item_id", "image_id") SELECT "id", "created_at", "room_id", "user_id", "open_date", "position", "rotation", "is_opened", "item_id", "image_id" FROM `calendar_item`;--> statement-breakpoint
+DROP TABLE `calendar_item`;--> statement-breakpoint
+ALTER TABLE `__new_calendar_item` RENAME TO `calendar_item`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE TABLE `__new_room` (
+	`id` text PRIMARY KEY NOT NULL,
+	`edit_id` text NOT NULL,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	`owner_id` text NOT NULL,
+	`password` text,
+	`is_anonymous` integer DEFAULT false NOT NULL,
+	`start_at` integer NOT NULL,
+	`item_get_time` integer,
+	`generate_count` integer DEFAULT 0 NOT NULL,
+	`snow_dome_parts_last_date` integer,
+	FOREIGN KEY (`owner_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_room`("id", "edit_id", "created_at", "owner_id", "password", "is_anonymous", "start_at", "item_get_time", "generate_count", "snow_dome_parts_last_date") SELECT "id", "edit_id", "created_at", "owner_id", "password", "is_anonymous", "start_at", "item_get_time", "generate_count", "snow_dome_parts_last_date" FROM `room`;--> statement-breakpoint
+DROP TABLE `room`;--> statement-breakpoint
+ALTER TABLE `__new_room` RENAME TO `room`;

--- a/backend/drizzle/meta/0006_snapshot.json
+++ b/backend/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,315 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "51da0a31-3b7e-49f6-8808-b140e2879e32",
+  "prevId": "be50fd4a-01be-4bbc-a297-4a202832b3a0",
+  "tables": {
+    "calendar_item": {
+      "name": "calendar_item",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "open_date": {
+          "name": "open_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rotation": {
+          "name": "rotation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_opened": {
+          "name": "is_opened",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "calendar_item_room_id_room_id_fk": {
+          "name": "calendar_item_room_id_room_id_fk",
+          "tableFrom": "calendar_item",
+          "tableTo": "room",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_item_user_id_user_id_fk": {
+          "name": "calendar_item_user_id_user_id_fk",
+          "tableFrom": "calendar_item",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_item_item_id_item_id_fk": {
+          "name": "calendar_item_item_id_item_id_fk",
+          "tableFrom": "calendar_item",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "item": {
+      "name": "item",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "room": {
+      "name": "room",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "edit_id": {
+          "name": "edit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_anonymous": {
+          "name": "is_anonymous",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_get_time": {
+          "name": "item_get_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "generate_count": {
+          "name": "generate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "snow_dome_parts_last_date": {
+          "name": "snow_dome_parts_last_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "room_owner_id_user_id_fk": {
+          "name": "room_owner_id_user_id_fk",
+          "tableFrom": "room",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1765774425527,
       "tag": "0005_deep_hitman",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1766241365070,
+      "tag": "0006_glossy_lockjaw",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -23,7 +23,7 @@ export const roomTable = sqliteTable("room", {
 
   ownerId: text("owner_id")
     .notNull()
-    .references(() => usersTable.id),
+    .references(() => usersTable.id, { onDelete: "cascade" }),
 
   password: text("password"),
   isAnonymous: integer("is_anonymous", { mode: "boolean" })
@@ -58,10 +58,10 @@ export const calendarItemTable = sqliteTable("calendar_item", {
     .default(sql`(unixepoch())`),
   roomId: text("room_id")
     .notNull()
-    .references(() => roomTable.id),
+    .references(() => roomTable.id, { onDelete: "cascade" }),
   userId: text("user_id")
     .notNull()
-    .references(() => usersTable.id),
+    .references(() => usersTable.id, { onDelete: "cascade" }),
   openDate: integer("open_date", { mode: "timestamp" }).notNull(),
   position: text("position"),
   rotation: text("rotation"),


### PR DESCRIPTION
close #69 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ユーザーやルームの削除時に、関連するカレンダーアイテムが自動的に削除されるようデータベースの動作を改善しました。これにより、データの整合性が向上します。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->