### PR TITLE
fix: 人の登録したオブジェクトが見れてしまう問題解決

### DIFF
--- a/frontend/src/routes/$roomId/$editId.lazy.tsx
+++ b/frontend/src/routes/$roomId/$editId.lazy.tsx
@@ -295,6 +295,22 @@ function RouteComponent() {
   }, [room, calendarItems, selectedDay]);
 
   const handleDayClick = (day: number) => {
+    // 他人の作成したアイテムがある場合はクリックを無効化
+    if (room && calendarItems && user) {
+      const startDate = new Date(room.startAt);
+      const existingItem = calendarItems.find((item) => {
+        const openDate = new Date(item.openDate);
+        const diffTime = openDate.getTime() - startDate.getTime();
+        const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24)) + 1;
+        return diffDays === day;
+      });
+
+      if (existingItem && existingItem.userId !== user.id) {
+        console.log("他人のアイテムは編集できません");
+        return;
+      }
+    }
+
     const drawerIndex = day - 1;
     setSelectedDay(day);
     setIsDialogOpen(true);


### PR DESCRIPTION
close #85 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 他のユーザーが作成したアイテムが既に存在する日付を選択した場合、編集画面が開かなくなるように改善しました。これにより、他のユーザーのアイテムが誤って編集されることを防ぎます。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->